### PR TITLE
Add Cloudback SaaS to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ handle the cronjob outside the docker-image, it is not designed to run stateful.
 
 ## Cloud Alternatives
 
-This list is by now means complete or curated - just things we found. If you have any good findings, add them :)
+This list is by no means complete or curated - just things we found. If you have any good findings, add them :)
 
 - https://gitprotect.io/
+- https://cloudback.it/github
 - https://rewind.com/pricing/
 
 


### PR DESCRIPTION
[Cloudback ](https://cloudback.it/)is a SaaS providing automatic daily backups and instant restores of GitHub repositories, metadata, and LFS.
I think it will make sense to add it to the list of cloud backup services.